### PR TITLE
stream json

### DIFF
--- a/logscol/collector.go
+++ b/logscol/collector.go
@@ -437,7 +437,10 @@ func Run() {
 
 	log.Println("Reading offsets db")
 	fp, err := os.Open(offsetsDb)
+
 	if err == nil {
+
+		offsetsMutex.Lock()
 
 		offsets = make(map[uint64]int64)
 		jsonDb := make([]*offsetsDbEntry, 0)
@@ -454,11 +457,15 @@ func Run() {
 			}
 		}
 
+		offsetsMutex.Unlock()
+
 		allInodes, err := getAllInodes(sourceDir)
 
 		if err != nil {
 			log.Panicln("Could not get all inodes from ", sourceDir, ": ", err.Error())
 		}
+
+		offsetsMutex.Lock()
 
 		for ino := range offsets {
 			if _, ok := allInodes[ino]; !ok {
@@ -466,6 +473,7 @@ func Run() {
 			}
 		}
 
+		offsetsMutex.Unlock()
 	}
 
 	log.Println("Saving offsets db")

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -1,7 +1,5 @@
 #!/bin/sh -x
-go build
-
-cp thunder thunder-test
+go build -o thunder-test
 
 rm -rf tmp-source tmp-target offsets.db offsets.db.tmp
 


### PR DESCRIPTION
У Гошного json есть прекрасные Decoder/Encoder которые позволяют не тащить лишний раз все данные в память  

В Run, вроде как, лок ставить особо и не нужно, для рейса остальные еще не запустились 

В saveOffsets мы же знаем offsets, можно "jsonDb" лишний раз не аллоцировать 

PS: smoke-test прошел, но, все на глаз, тестов на  collector чтоб их прогнать, к сожалению, нет
